### PR TITLE
drop beam from index page to avoid design conflict with JB

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -323,17 +323,18 @@ footer .footer__copyright a, footer .footer__copyright a:hover {
 }
 
 .first-page {
-    min-height: max(100vh + 50px, 700px);
+    min-height: 560px;
     box-sizing: border-box;
     font-size: 1.75em;
     text-align: center;
-    color: #19191C;
+    color: #fff;
+    background-color: #6059f7;
     margin-top: -56px;
     position: relative;
 }
 
 .first-page .first-page__inner {
-    padding-top: 140px;
+    padding-top: 120px;
     max-width: 924px;
     margin-right: auto;
     margin-left: auto;
@@ -350,7 +351,7 @@ footer .footer__copyright a, footer .footer__copyright a:hover {
 }
 
 .first-page .first-page__vk_logo {
-    margin-top: 90px;
+    margin-top: 30px;
     font-size: 0;
     vertical-align: top;
 }
@@ -398,12 +399,12 @@ footer .footer__copyright a, footer .footer__copyright a:hover {
 }
 
 .first-page .first-page__download-button {
-    color: #fff;
+    color: #19191C;
     display: inline-block;
     line-height: 48px;
     font-size: 12pt;
     font-weight: 300;
-    background: rgb(39, 40, 44);
+    background: #fff;
     padding: 0 40px;
     border-radius: 24px;
     margin-bottom: 20px;
@@ -417,7 +418,7 @@ footer .footer__copyright a, footer .footer__copyright a:hover {
 }
 
 .first-page .first-page__download-button:hover {
-    background-color: rgba(59, 62, 67, 0.7);
+    background-color: rgba(255, 255, 255, 0.7);
 }
 
 .chapter {

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,57 +42,19 @@
     </div>
 </header>
 
-<div class="c-beam">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1313 1156" id="beam">
-        <defs>
-            <linearGradient x1="43.164%" y1="98.551%" x2="56.703%" y2="13.241%" id="beam-1_a">
-                <stop stop-color="#FF6C93" offset="0%"></stop>
-                <stop stop-color="#FF438B" offset="100%"></stop>
-            </linearGradient>
-            <linearGradient x1="44.733%" y1="13.063%" x2="57.576%" y2="87.809%" id="beam-1_b">
-                <stop stop-color="#FF318C" offset="0%"></stop>
-                <stop stop-color="#FF438B" offset="100%"></stop>
-            </linearGradient>
-            <linearGradient x1="10.542%" y1="44.612%" x2="82.212%" y2="56.679%" id="beam-1_c">
-                <stop stop-color="#FF318C" offset="0%"></stop>
-                <stop stop-color="#765AF8" offset="100%"></stop>
-            </linearGradient>
-            <linearGradient x1="7.476%" y1="49.697%" x2="91.046%" y2="50.357%" id="beam-1_d">
-                <stop stop-color="#B345F1" offset="0%"></stop>
-                <stop stop-color="#765AF8" offset="100%"></stop>
-            </linearGradient>
-            <linearGradient x1="7.447%" y1="51.203%" x2="82.257%" y2="46.892%" id="beam-1_e">
-                <stop stop-color="#B345F1" offset="0%"></stop>
-                <stop stop-color="#F445F1" offset="100%"></stop>
-            </linearGradient>
-        </defs>
-        <g fill-rule="nonzero" fill="none">
-            <path fill="url(#beam-1_a)" d="M692.8 1200H740l147.5-252.4-45.4-30.8z"
-                  transform="translate(0 -44)"></path>
-            <path fill="url(#beam-1_b)" d="M550 554.5l282 468.4 55.5-75.3-267.4-456.9-91.2-21.6z"
-                  transform="translate(0 -44)"></path>
-            <path fill="url(#beam-1_c)" d="M1167.9 728.9l-96.3 189.4-474-290.6-47.6-73.2-21.1-85.4 91.2 21.6z"
-                  transform="translate(0 -44)"></path>
-            <path fill="url(#beam-1_d)" d="M0 520l54.1 188.6 1017.5 209.7 96.3-189.4z"
-                  transform="translate(0 -44)"></path>
-            <path fill="url(#beam-1_e)" d="M740 0h661v231.2L54.1 708.6 0 520z" transform="translate(0 -44)"></path>
-        </g>
-    </svg>
-</div>
-
 <div class="first-page">
 
     <div class="first-page__inner">
         <h1 class="first-page__title">
             <span>Mod</span><span style="margin-left: -3px;">ulite</span>
         </h1>
-        <p class="first-page__description">Честная модульность внутри PHP</p>
+        <p class="first-page__description">Честные модули внутри PHP</p>
         <div class="first-page__download-block">
             <a href="install.html" class="first-page__download-button">Установить</a>
         </div>
         <div class="first-page__vk_logo">
             <svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg">
-                <path clip-rule="evenodd" fill-rule="evenodd" fill="#000"
+                <path clip-rule="evenodd" fill-rule="evenodd" fill="#fff"
                       d="m3.37413 3.37413c-3.37413 3.37413-3.37413 8.80467-3.37413 19.66587v1.92c0 10.8612 0 16.2917 3.37413 19.6659 3.37413 3.3741 8.80467 3.3741 19.66587 3.3741h1.92c10.8612 0 16.2917 0 19.6659-3.3741 3.3741-3.3742 3.3741-8.8047 3.3741-19.6659v-1.92c0-10.8612 0-16.29174-3.3741-19.66587-3.3742-3.37413-8.8047-3.37413-19.6659-3.37413h-1.92c-10.8612 0-16.29174 0-19.66587 3.37413zm4.72587 11.22607c.26 12.48 6.4999 19.9799 17.4399 19.9799h.6202v-7.14c4.02.4 7.0597 3.34 8.2797 7.14h5.6802c-1.56-5.68-5.6602-8.82-8.2202-10.02 2.56-1.48 6.16-5.0799 7.02-9.9599h-5.1601c-1.12 3.96-4.4396 7.5599-7.5996 7.8999v-7.8999h-5.1602v13.8399c-3.2-.8-7.2399-4.6799-7.4199-13.8399z"/>
             </svg>
         </div>


### PR DESCRIPTION
An index page now will look like this
<img width="641" alt="image" src="https://user-images.githubusercontent.com/67757852/212293766-3dc971b6-3711-40af-b55d-8b8867f68b28.png">
