### PR TITLE
probably fix UninitializedPropertyAccessException

### DIFF
--- a/src/main/kotlin/com/vk/modulite/services/ModuliteIndex.kt
+++ b/src/main/kotlin/com/vk/modulite/services/ModuliteIndex.kt
@@ -85,11 +85,14 @@ class ModuliteIndex(private var project: Project) {
 
     fun getModulite(name: String, composerPackageName: SymbolName): Modulite? {
         val allScope = GlobalSearchScope.allScope(project)
-        val modulites = FileBasedIndex.getInstance()
+        val modulitesFromIndex = FileBasedIndex.getInstance()
             .getValues(ModuliteFilesIndex.KEY, name, allScope)
+        modulitesFromIndex.forEach(::modulitePostProcess)
+
+        val modulites = modulitesFromIndex
             .filter { it.containingPackage?.symbolName() == composerPackageName }
+
         return modulites.firstOrNull()
-            .also { modulitePostProcess(it) }
     }
 
     private fun modulitePostProcess(it: Modulite?) {


### PR DESCRIPTION
The case: sometimes UPAE throws with stacktrace:

```
kotlin.UninitializedPropertyAccessException: lateinit property project has not been initialized
	at com.vk.modulite.modulite.ModuliteBase.getProject(ModuliteBase.kt:21)
	at com.vk.modulite.modulite.Modulite$containingPackage$2.invoke(Modulite.kt:48)
	at com.vk.modulite.modulite.Modulite$containingPackage$2.invoke(Modulite.kt:47)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at com.vk.modulite.modulite.Modulite.getContainingPackage(Modulite.kt:47)
	at com.vk.modulite.services.ModuliteIndex.getModulite(ModuliteIndex.kt:90)
	at com.vk.modulite.SymbolName.resolve(SymbolName.kt:123)
	at com.vk.modulite.psi.extensions.yaml.ExtensionsKt.resolveSymbol(Extensions.kt:48)
	at com.vk.modulite.inspections.config.RequireSymbolFromModuliteInspection$buildVisitor$1.visitQuotedText(RequireSymbolFromModuliteInspection.kt:38)
	at org.jetbrains.yaml.psi.impl.YAMLQuotedTextImpl.accept(YAMLQuotedTextImpl.java:262)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner$InspectionProblemHolder.visitElement(InspectionRunner.java:577)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$processContext$18(InspectionRunner.java:404)
	at com.intellij.codeInsight.daemon.impl.InspectionVisitorOptimizer.acceptElements(InspectionVisitorOptimizer.java:216)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.processContext(InspectionRunner.java:402)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$inspect$7(InspectionRunner.java:178)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:333)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:972)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$executeInImpatientReadAction$14(InspectionRunner.java:377)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.executeByImpatientReader(AnyThreadWriteThreadingSupport.kt:544)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:176)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$executeInImpatientReadAction$15(InspectionRunner.java:376)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:158)
	at com.intellij.util.AstLoadingFilter.forceAllowTreeLoading(AstLoadingFilter.java:150)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$executeInImpatientReadAction$16(InspectionRunner.java:374)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:129)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:118)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.executeInImpatientReadAction(InspectionRunner.java:374)
	at com.intellij.codeInsight.daemon.impl.InspectionRunner.lambda$inspect$8(InspectionRunner.java:171)
	at com.intellij.concurrency.ApplierCompleter.processArrayItem(ApplierCompleter.java:126)
	at com.intellij.concurrency.ApplierCompleter.processArray(ApplierCompleter.java:207)
	at com.intellij.concurrency.ApplierCompleter.execAll(ApplierCompleter.java:176)
	at com.intellij.concurrency.ApplierCompleter.lambda$exec$0(ApplierCompleter.java:115)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:351)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:972)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapInReadActionAndIndicator$2(ApplierCompleter.java:158)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$14(CoreProgressManager.java:674)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:749)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:705)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:673)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:79)
	at com.intellij.concurrency.ApplierCompleter.wrapInReadActionAndIndicator(ApplierCompleter.java:169)
	at com.intellij.concurrency.ApplierCompleter.lambda$wrapAndRun$1(ApplierCompleter.java:150)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.executeByImpatientReader(AnyThreadWriteThreadingSupport.kt:544)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:176)
	at com.intellij.concurrency.ApplierCompleter.wrapAndRun(ApplierCompleter.java:150)
	at com.intellij.concurrency.ApplierCompleter.exec(ApplierCompleter.java:118)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
```

The problem in the lateinit field in the base class `ModuliteBase`. The value is being put in manual way in some cases. However, in this case it isn't. The simplest solution is present in this PR. We also can process this case (`project == null`) in some other way, but I do not understand the logic well, so, any suggestions are welcome 