### PR TITLE
use `ActionUpdateThread.BGT` in actions to fix IDE errors

### DIFF
--- a/src/main/kotlin/com/vk/modulite/actions/NewModuliteAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/NewModuliteAction.kt
@@ -1,6 +1,7 @@
 package com.vk.modulite.actions
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -15,5 +16,9 @@ class NewModuliteAction : AnAction(
         val project = e.project ?: return
         val folder = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
         ModuliteBuilder(project).startBuild(folder, fromSource = false)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/vk/modulite/actions/NewModuliteAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/NewModuliteAction.kt
@@ -18,7 +18,5 @@ class NewModuliteAction : AnAction(
         ModuliteBuilder(project).startBuild(folder, fromSource = false)
     }
 
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
-    }
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 }

--- a/src/main/kotlin/com/vk/modulite/actions/NewModuliteFromFolderAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/NewModuliteFromFolderAction.kt
@@ -37,7 +37,5 @@ class NewModuliteFromFolderAction : AnAction(
         }
     }
 
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
-    }
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 }

--- a/src/main/kotlin/com/vk/modulite/actions/NewModuliteFromFolderAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/NewModuliteFromFolderAction.kt
@@ -1,6 +1,7 @@
 package com.vk.modulite.actions
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -34,5 +35,9 @@ class NewModuliteFromFolderAction : AnAction(
             e.presentation.isEnabled = false
             return
         }
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/vk/modulite/actions/RegenerateModuleRequiresAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/RegenerateModuleRequiresAction.kt
@@ -21,7 +21,5 @@ class RegenerateModuleRequiresAction : AnAction() {
         }
     }
 
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
-    }
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 }

--- a/src/main/kotlin/com/vk/modulite/actions/RegenerateModuleRequiresAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/RegenerateModuleRequiresAction.kt
@@ -1,5 +1,6 @@
 package com.vk.modulite.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -17,7 +18,10 @@ class RegenerateModuleRequiresAction : AnAction() {
         val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
         if (file == null || file.name != ".modulite.yaml") {
             e.presentation.isEnabledAndVisible = false
-            return
         }
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/com/vk/modulite/actions/SelectionBasedPsiElementAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/SelectionBasedPsiElementAction.kt
@@ -106,9 +106,7 @@ abstract class SelectionBasedPsiElementAction<T : PsiElement>(
         return PsiTreeUtil.findElementOfClassAtRange(file, selectionStart, selectionEnd, myClass)
     }
 
-    override fun getActionUpdateThread(): ActionUpdateThread {
-        return ActionUpdateThread.BGT
-    }
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     companion object {
         private fun getEditor(e: AnActionEvent) = e.getData(CommonDataKeys.EDITOR)

--- a/src/main/kotlin/com/vk/modulite/actions/SelectionBasedPsiElementAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/SelectionBasedPsiElementAction.kt
@@ -1,6 +1,7 @@
 package com.vk.modulite.actions
 
 import com.intellij.codeInsight.hint.HintManager
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
@@ -103,6 +104,10 @@ abstract class SelectionBasedPsiElementAction<T : PsiElement>(
         val selectionStart = selectionModel.selectionStart
         val selectionEnd = selectionModel.selectionEnd
         return PsiTreeUtil.findElementOfClassAtRange(file, selectionStart, selectionEnd, myClass)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 
     companion object {

--- a/src/main/kotlin/com/vk/modulite/actions/usages/base/UsagesBaseFinder.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/usages/base/UsagesBaseFinder.kt
@@ -60,6 +60,7 @@ abstract class UsagesBaseFinder {
             it is DefaultSearchScopeProviders.CustomNamed
         } ?: return
 
+        // TODO: remove `allowSlowOperations`
         val scopes = SlowOperations.allowSlowOperations<List<SearchScope>, RuntimeException> {
             provider.getSearchScopes(
                 element.project,

--- a/src/main/kotlin/com/vk/modulite/actions/usages/php/FindSymbolUsagesInCurrentModuleAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/usages/php/FindSymbolUsagesInCurrentModuleAction.kt
@@ -2,11 +2,9 @@ package com.vk.modulite.actions.usages.php
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.util.SlowOperations
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement
 import com.jetbrains.php.lang.psi.elements.Variable
 import com.vk.modulite.actions.PhpPsiElementAction
-import com.vk.modulite.modulite.Modulite
 import com.vk.modulite.psi.extensions.files.containingModulite
 
 class FindSymbolUsagesInCurrentModuleAction : PhpPsiElementAction<PhpPsiElement>(PhpPsiElement::class.java) {
@@ -20,9 +18,7 @@ class FindSymbolUsagesInCurrentModuleAction : PhpPsiElementAction<PhpPsiElement>
             return
         }
 
-        val modulite = SlowOperations.allowSlowOperations<Modulite?, RuntimeException> {
-            e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
-        }
+        val modulite = e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
 
         if (modulite == null) {
             e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindAllowedSymbolUsagesInModuleAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindAllowedSymbolUsagesInModuleAction.kt
@@ -1,5 +1,6 @@
 package com.vk.modulite.actions.usages.yaml
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.util.SlowOperations
@@ -19,9 +20,7 @@ class FindAllowedSymbolUsagesInModuleAction : YamlPsiElementAction<YAMLQuotedTex
     }
 
     override fun update(e: AnActionEvent, element: YAMLQuotedText?) {
-        val modulite = SlowOperations.allowSlowOperations<Modulite?, RuntimeException> {
-            e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
-        }
+        val modulite = e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
 
         if (element == null || modulite == null) {
             e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindModuleUsagesInCurrentModuleAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindModuleUsagesInCurrentModuleAction.kt
@@ -1,5 +1,6 @@
 package com.vk.modulite.actions.usages.yaml
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.PsiElement
@@ -40,10 +41,7 @@ class FindModuleUsagesInCurrentModuleAction : YamlPsiElementAction<YAMLQuotedTex
     }
 
     override fun update(e: AnActionEvent, element: YAMLQuotedText?) {
-        val module =
-            SlowOperations.allowSlowOperations<Modulite?, RuntimeException> {
-                e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
-            }
+        val module = e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
 
         if (element == null || module == null) {
             e.presentation.isEnabledAndVisible = false

--- a/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindSymbolUsagesInCurrentModuleAction.kt
+++ b/src/main/kotlin/com/vk/modulite/actions/usages/yaml/FindSymbolUsagesInCurrentModuleAction.kt
@@ -1,5 +1,6 @@
 package com.vk.modulite.actions.usages.yaml
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.util.SlowOperations
@@ -15,10 +16,7 @@ class FindSymbolUsagesInCurrentModuleAction : YamlPsiElementAction<YAMLQuotedTex
     }
 
     override fun update(e: AnActionEvent, element: YAMLQuotedText?) {
-        val modulite =
-            SlowOperations.allowSlowOperations<Modulite?, RuntimeException> {
-                e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
-            }
+        val modulite = e.getData(CommonDataKeys.VIRTUAL_FILE)?.containingModulite(e.project!!)
 
         if (element == null || modulite == null) {
             e.presentation.isEnabledAndVisible = false


### PR DESCRIPTION
Previously, `getActionUpdateThread` [was added to the IntelliJ Platform](https://plugins.jetbrains.com/docs/intellij/api-notable-list-2022.html#z53vdll_35). Then, some restrictions were introduces to the `update` method of `AnAction` class. Now, any non-ui-interaction operation must be called on BGT. It also allows us to get ride of `SlowOperations.allowSlowOperations` use which is tagged `@Depricated` now.

I have it tested as much as I can. However, I would like to ask some manual testing by any maintainer